### PR TITLE
Add Prepare API 

### DIFF
--- a/JitterBuffer.cpp
+++ b/JitterBuffer.cpp
@@ -63,7 +63,6 @@ JitterBuffer::~JitterBuffer() {
 }
 
 std::size_t JitterBuffer::Prepare(const std::uint32_t sequence_number, const ConcealmentCallback &concealment_callback) {
-  std::cout << sequence_number << std::endl;
   if (!last_written_sequence_number.has_value()) {
     // Nothing to do.
     return 0;

--- a/JitterBuffer.cpp
+++ b/JitterBuffer.cpp
@@ -103,7 +103,7 @@ std::size_t JitterBuffer::Enqueue(const std::vector<Packet> &packets, const Conc
         logger->warning << "Discontinuity detected. Last written was: " << last << " this is: " << packet.sequence_number << " need: " << missing << std::flush;
         const auto concealed = GenerateConcealment(missing, concealment_callback);
         enqueued += concealed;
-        this->metrics.concealed_packets += concealed;
+        this->metrics.concealed_frames += concealed;
       }
     }
 

--- a/JitterBuffer.cpp
+++ b/JitterBuffer.cpp
@@ -80,10 +80,10 @@ std::size_t JitterBuffer::Prepare(const std::uint32_t sequence_number, const Con
   }
 
   // In all other cases, we're missing packets.
-  const std::size_t missing = sequence_number - last - 1;
-  const std::size_t concealed = GenerateConcealment(missing, concealment_callback);
-  this->metrics.concealed_packets += concealed;
-  return concealed;
+  const std::size_t missing_packets = sequence_number - last - 1;
+  const std::size_t concealed_frames = GenerateConcealment(missing_packets, concealment_callback);
+  this->metrics.concealed_frames += concealed_frames;
+  return concealed_frames;
 }
 
 std::size_t JitterBuffer::Enqueue(const std::vector<Packet> &packets, const ConcealmentCallback &concealment_callback) {

--- a/include/JitterBuffer.hh
+++ b/include/JitterBuffer.hh
@@ -50,6 +50,14 @@ class JitterBuffer {
   ~JitterBuffer();
 
   /**
+   * @brief Prepare the buffer for the given sequence number, generating concealment data for any missing packets.
+   * 
+   * @param sequence_number The sequence number to prepare for.
+   * @param concealment_callback Fired when concealment data needs to be generated. 
+   */
+  std::size_t Prepare(const std::uint32_t sequence_number, const ConcealmentCallback &concealment_callback);
+
+  /**
    * @brief Enqueue a number of packets onto the buffer. This must be called from a single writer thread.
    *
    * @param packets The packets to enqueue.

--- a/include/Metrics.h
+++ b/include/Metrics.h
@@ -4,7 +4,7 @@
 /// @brief Structure defining metrics LibJitter reports.
 struct Metrics {
   /// @brief Number of frames concealed due to a discontinuity.
-  unsigned long concealed_packets;
+  unsigned long concealed_frames;
   /// @brief Number of frames skipped due to expiry.
   unsigned long skipped_frames;
   /// @brief Number of frames concealed to fill to minimum depth.

--- a/include/libjitter.h
+++ b/include/libjitter.h
@@ -24,6 +24,14 @@ typedef void (*LibJitterConcealmentCallback)(struct Packet *, const size_t num_p
    */
 void *JitterInit(size_t element_size, size_t packet_elements, unsigned long clock_rate, unsigned long max_length_ms, unsigned long min_length_ms, cantina::Logger *logger);
 
+/// @brief Prepare the buffer for the given sequence number, generating concealment data for any missing packets.
+/// @param libjitter The jitter buffer instance.
+/// @param sequence_number The sequence number to prepare for.
+/// @param concealment_callback Fired when concealment data needs to be generated.
+/// @param user_data User data pointer passed to concealment_callback.
+/// @return Number of elements concealed.
+size_t JitterPrepare(void* libjitter, const unsigned long sequence_number, LibJitterConcealmentCallback concealment_callback, void *user_data);
+
 /// @brief Enqueue packets of data.
 /// @param libjitter
 /// @param packets Array of packets of data.

--- a/libjitter.cpp
+++ b/libjitter.cpp
@@ -18,6 +18,22 @@ void *JitterInit(const size_t element_size,
                           cantina::LoggerPointer(logger));
 }
 
+size_t JitterPrepare(void *libjitter,
+                     const unsigned long sequence_number,
+                     const LibJitterConcealmentCallback concealment_callback,
+                     void *user_data) {
+  auto *buffer = static_cast<JitterBuffer *>(libjitter);
+  JitterBuffer::ConcealmentCallback callback = [concealment_callback, user_data](std::vector<Packet> &packets) {
+    concealment_callback(&packets[0], packets.capacity(), user_data);
+  };
+  try {
+    return buffer->Prepare(sequence_number, callback);
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << std::endl;
+    return 0;
+  }
+}
+
 size_t JitterEnqueue(void *libjitter,
                      const Packet packets[],
                      const size_t elements,


### PR DESCRIPTION
Adds a prepare API whereby a sequence number can be submitted to call any appropriate concealment callbacks in order to make the buffer ready for the `Enqueue` of said sequence number's packet data. This is useful when your concealment is stateful and you need it to be generated before you decode your to-be-enqueued data. 

For example:

- Packet `1` has arrived, been decoded and `Enqueue`'d into the buffer
- Packet 3 just arrived.
- Call `Prepare(3)` to generate and enqueue missing packet `2`
- Now we are in a state where `3` can be decoded and `Enqueue`'d